### PR TITLE
Fix appdata paper cuts

### DIFF
--- a/data/io.github.thiefmd.themegenerator.appdata.xml
+++ b/data/io.github.thiefmd.themegenerator.appdata.xml
@@ -18,17 +18,6 @@
   <content_rating type="oars-1.1">
     <content_attribute id="language-humor">mild</content_attribute>
   </content_rating>
-  <categories>
-    <category>Utility</category>
-  </categories>
-  <keywords>
-    <keyword>markdown</keyword>
-    <keyword>ulysses</keyword>
-    <keyword>customization</keyword>
-    <keyword>gtksourceview</keyword>
-    <keyword>sourceview</keyword>
-    <keyword>thiefmd</keyword>
-  </keywords>
   <screenshots>
     <screenshot type="default">
       <caption>Theme Generator Window</caption>

--- a/data/io.github.thiefmd.themegenerator.appdata.xml
+++ b/data/io.github.thiefmd.themegenerator.appdata.xml
@@ -1,23 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2018 Miles Wallio <mwallio@gmail.com> -->
-<component type="desktop">
-  <id>io.github.thiefmd.themegenerator.desktop</id>
+<component type="desktop-application">
+  <id>io.github.thiefmd.themegenerator</id>
   <metadata_license>MIT</metadata_license>
   <project_license>MIT</project_license>
   <name>ThemeGenerator</name>
-  <launchable type="desktop-id">io.github.thiefmd.themegenerator.desktop</launchable>
-  <summary>Generate Styles with Style.</summary>
+  <summary>Generate Styles with Style</summary>
   <description>
     <p>Need to generate a Ultheme or GtkSourceView Scheme for Markdown? Look no further.</p>
     <p>Themes are compatible with ThiefMD, gedit, GNOME Builder, Editors based on GtkSourceView, and Ulysses.</p>
   </description>
-  <developer_name>kmwallio</developer_name>
+  <developer id="io.github.kmwallio">
+    <name>kmwallio</name>
+  </developer>
   <url type="homepage">https://github.com/ThiefMD/theme-generator</url>
   <url type="bugtracker">https://github.com/ThiefMD/theme-generator/issues</url>
+  <url type="vcs-browser">https://github.com/ThiefMD/theme-generator</url>
   <url type="help">https://themes.thiefmd.com/howto</url>
+  <launchable type="desktop-id">io.github.thiefmd.themegenerator.desktop</launchable>
   <content_rating type="oars-1.1">
     <content_attribute id="language-humor">mild</content_attribute>
   </content_rating>
+  <provides>
+    <id>io.github.thiefmd.themegenerator.desktop</id>
+  </provides>
+  <replaces>
+      <id>io.github.thiefmd.themegenerator.desktop</id>
+  </replaces>
   <screenshots>
     <screenshot type="default">
       <caption>Theme Generator Window</caption>

--- a/data/io.github.thiefmd.themegenerator.appdata.xml
+++ b/data/io.github.thiefmd.themegenerator.appdata.xml
@@ -50,6 +50,12 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.1.4" date="2026-02-11" urgency="low">
+      <description>
+        <p>Updated to GTK4 and GtkSourceView 5</p>
+      </description>
+      <url>https://github.com/ThiefMD/theme-generator/releases/tag/v0.1.4</url>
+    </release>
     <release version="0.1.3" date="2022-07-09" urgency="low">
       <description>
         <p>Maintanence release for updating build to latest SDK</p>

--- a/data/io.github.thiefmd.themegenerator.desktop
+++ b/data/io.github.thiefmd.themegenerator.desktop
@@ -7,4 +7,4 @@ Exec=io.github.thiefmd.themegenerator
 Icon=io.github.thiefmd.themegenerator
 Terminal=false
 Type=Application
-Keywords=markdown;style;editor;
+Keywords=markdown;style;editor;ulysses;customization;gtksourceview;sourceview;thiefmd;


### PR DESCRIPTION
### Fix appdata paper cuts

- Use the desktop-application as a component type
- Use the developer block instead of the developer_name tag
- Add missing vcs-browser URL
- Drop .desktop extension from the ID and add provides and replaces tag
- Remove the dot from the summary

### Move categories and keywords to desktop file

> **Categories and keywords**
>
> If there’s a launchable defined for a desktop application, categories and keywords are pulled from the desktop file.
> Defining them separately in the Metainfo file will override the contents of the desktop file.

See: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines#categories-and-keywords

### Add missing release information